### PR TITLE
Fix compile error of Google OAuth2.0 example

### DIFF
--- a/source/documentation/oauth.html.md.erb
+++ b/source/documentation/oauth.html.md.erb
@@ -105,8 +105,7 @@ https://console.developers.google.com/
 import skinny.controller.feature.GoogleLoginFeature
 import skinny.oauth2.client.google.GoogleUser
 
-class SessionsController extends ApplicationController with GoogleLoginFeature
-  with SkinnySessionOAuth2LoginFeature[GoogleUser] with SkinnyFilter {
+class SessionsController extends ApplicationController with GoogleLoginFeature {
 
   // these env variables are expected by default
   // SKINNY_OAUTH2_CLIENT_ID_GOOGLE


### PR DESCRIPTION
SkinnySessionOAuth2LoginFeature requires SkinnySessionFilter trait.
Remove SkinnySessionOAuth2LoginFeature and SkinnyFilter trait according to other examples.

...or should change to SkinnySessionFilter?