### PR TITLE
Replace `Build.scala` with `build.sbt`

### DIFF
--- a/source/documentation/getting-started.html.md
+++ b/source/documentation/getting-started.html.md
@@ -161,7 +161,6 @@ The following tree shows the directories and files in skinny-blank-app project. 
 │   └── sbt-launch.jar # global sbt script in PATH is given priority over this
 ├── build.sbt
 ├── project
-│   ├── Build.scala
 │   ├── build.properties
 │   └── plugins.sbt
 ├── sbt      # Skinny uses this sbt command

--- a/source/documentation/oauth.html.md.erb
+++ b/source/documentation/oauth.html.md.erb
@@ -17,7 +17,7 @@ https://oltu.apache.org/
 
 `skinny-oauth2-controller` contains Facebook, GitHub and Google login features.
 
-Add the following dependency in your `project/Build.scala`.
+Add the following dependency in your `build.sbt`.
 
 ```scala
 libraryDependencies += "org.skinny-framework" %% "skinny-oauth2-controller" % "<%= skinny_version %>"
@@ -224,7 +224,7 @@ http://twitter4j.org/en/index.html
 
 <hr/>
 
-Add the following dependency in your `project/Build.scala`.
+Add the following dependency in your `build.sbt`.
 
 ```scala
 libraryDependencies += "org.skinny-framework" %% "skinny-twitter-controller" % skinnyVersion


### PR DESCRIPTION
`Build.scala` was replaced with `build.sbt` in 2.2. This PR follows that :D